### PR TITLE
Refactoring/relation thread image path

### DIFF
--- a/app/Http/Controllers/Dashboard/LikeController.php
+++ b/app/Http/Controllers/Dashboard/LikeController.php
@@ -54,7 +54,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'club_thread_id' => $club_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -65,7 +65,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'college_year_thread_id' => $college_year_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -76,7 +76,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'department_thread_id' => $department_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -87,7 +87,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'job_hunting_thread_id' => $job_hunting_thread_id,
                     'user_id' => $request->user()->id
                 ]);
@@ -98,7 +98,7 @@ class LikeController extends Controller
                     ->where('message_id', '=', $request->message_id)
                     ->first()
                     ->id;
-                Like::insertOrIgnore([
+                Like::create([
                     'lecture_thread_id' => $lecture_thread_id,
                     'user_id' => $request->user()->id
                 ]);

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/ClubThreadController.php
@@ -20,19 +20,15 @@ class ClubThreadController extends Controller
     {
         return ClubThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
-            })
-            ->where('club_threads.hub_id', '=', $thread_id)
-            ->where('club_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('club_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/CollegeYearThreadController.php
@@ -20,19 +20,15 @@ class CollegeYearThreadController extends Controller
     {
         return CollegeYearThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
-            })
-            ->where('college_year_threads.hub_id', '=', $thread_id)
-            ->where('college_year_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('college_year_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/DepartmentThreadController.php
@@ -20,19 +20,15 @@ class DepartmentThreadController extends Controller
     {
         return DepartmentThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
-            })
-            ->where('department_threads.hub_id', '=', $thread_id)
-            ->where('department_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('department_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/JobHuntingThreadController.php
@@ -20,19 +20,15 @@ class JobHuntingThreadController extends Controller
     {
         return JobHuntingThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
-            })
-            ->where('job_hunting_threads.hub_id', '=', $thread_id)
-            ->where('job_hunting_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('job_hunting_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
+++ b/app/Http/Controllers/Dashboard/NotLoggedIn/LectureThreadController.php
@@ -20,19 +20,15 @@ class LectureThreadController extends Controller
     {
         return LectureThread::with([
             'user',
+            'thread_image_path',
             'likes' => function ($query) use ($user_id) {
                 $query->where('user_id', '=', $user_id);
             }
         ])
             ->withCount('likes')
-            ->leftjoin('thread_image_paths', function ($join) {
-                $join
-                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.hub_id')
-                    ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
-            })
-            ->where('lecture_threads.hub_id', '=', $thread_id)
-            ->where('lecture_threads.message_id', '>', $pre_max_message_id)
-            ->groupBy('lecture_threads.message_id')
+            ->where('hub_id', '=', $thread_id)
+            ->where('message_id', '>', $pre_max_message_id)
+            ->groupBy('message_id')
             ->get();
     }
 }

--- a/app/Http/Controllers/Dashboard/ThreadImagePathController.php
+++ b/app/Http/Controllers/Dashboard/ThreadImagePathController.php
@@ -3,8 +3,14 @@
 namespace App\Http\Controllers\Dashboard;
 
 use App\Http\Controllers\Controller;
+use App\Models\ClubThread;
+use App\Models\CollegeYearThread;
+use App\Models\DepartmentThread;
+use App\Models\JobHuntingThread;
+use App\Models\LectureThread;
 use App\Models\ThreadImagePath;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;
 use Intervention\Image\Facades\Image;
 use Illuminate\Support\Facades\Storage;
@@ -39,23 +45,73 @@ class ThreadImagePathController extends Controller
      *
      * @return void
      */
-    public function store(Request $request, int $message_id)
+    public function store(UploadedFile $img = null, string $user_id, string $thread_id, int $message_id, $category_type)
     {
-        if ($request->file('img')) {
-            $img = Image::make($request->file('img'))->encode('jpg')->orientate()->save();
+        if ($img) {
+            $img = Image::make($img)->encode('jpg')->orientate()->save();
 
             $size = $img->filesize();
             $path = 'public/images/thread_message/' . str_replace('-', '', Str::uuid()) . '.jpg';
             Storage::put($path, $img);
 
             if ($path) {
-                ThreadImagePath::create([
-                    'thread_id' => $request->thread_id,
-                    'message_id' => $message_id,
-                    'user_email' => $request->user()->email,
-                    'img_path' => $path,
-                    'img_size' => $size
-                ]);
+                switch ($category_type) {
+                    case '部活':
+                        ThreadImagePath::create([
+                            'club_thread_id' => ClubThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '学年':
+                        ThreadImagePath::create([
+                            'college_year_thread_id' => CollegeYearThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '学科':
+                        ThreadImagePath::create([
+                            'department_thread_id' => DepartmentThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '就職':
+                        ThreadImagePath::create([
+                            'job_hunting_thread_id' => JobHuntingThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                    case '授業':
+                        ThreadImagePath::create([
+                            'lecture_thread_id' => LectureThread::where('hub_id', '=', $thread_id)
+                                ->where('message_id', '=', $message_id)
+                                ->first()
+                                ->id,
+                            'user_id' => $user_id,
+                            'img_path' => $path,
+                            'img_size' => $size
+                        ]);
+                        break;
+                }
             }
 
             $img->destroy();

--- a/app/Http/Controllers/Dashboard/ThreadImagePathController.php
+++ b/app/Http/Controllers/Dashboard/ThreadImagePathController.php
@@ -40,12 +40,15 @@ class ThreadImagePathController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\UploadedFile $img
+     * @param string $user_id
+     * @param string $thread_id
      * @param int $message_id
+     * @param string $category_type
      *
      * @return void
      */
-    public function store(UploadedFile $img = null, string $user_id, string $thread_id, int $message_id, $category_type)
+    public function store(UploadedFile $img = null, string $user_id, string $thread_id, int $message_id, string $category_type)
     {
         if ($img) {
             $img = Image::make($img)->encode('jpg')->orientate()->save();

--- a/app/Http/Controllers/Dashboard/ThreadsController.php
+++ b/app/Http/Controllers/Dashboard/ThreadsController.php
@@ -44,24 +44,25 @@ class ThreadsController extends Controller
             ->first();
 
         switch ($thread->thread_category->category_type) {
-            case '学科':
-                $message_id = (new DepartmentThreadController)->store($request->thread_id, $request->user()->id, $message);
+            case '部活':
+                $message_id = (new ClubThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '学年':
                 $message_id = (new CollegeYearThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
-            case '部活':
-                $message_id = (new ClubThreadController)->store($request->thread_id, $request->user()->id, $message);
+            case '学科':
+                $message_id = (new DepartmentThreadController)->store($request->thread_id, $request->user()->id, $message);
+                break;
+            case '就職':
+                $message_id = (new JobHuntingThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
             case '授業':
                 $message_id = (new LectureThreadController)->store($request->thread_id, $request->user()->id, $message);
                 break;
-            case '就職':
-                $message_id = (new JobHuntingThreadController)->store($request->thread_id, $request->user()->id, $message);
             default:
                 break;
         }
 
-        (new ThreadImagePathController)->store($request, $message_id);
+        (new ThreadImagePathController)->store($request->file('img'), $request->user()->id, $request->thread_id, $message_id, $thread->thread_category->category_type);
     }
 }

--- a/app/Models/ClubThread.php
+++ b/app/Models/ClubThread.php
@@ -77,4 +77,12 @@ class ClubThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the club thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/CollegeYearThread.php
+++ b/app/Models/CollegeYearThread.php
@@ -78,4 +78,12 @@ class CollegeYearThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the college year thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/DepartmentThread.php
+++ b/app/Models/DepartmentThread.php
@@ -78,4 +78,12 @@ class DepartmentThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the department thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/JobHuntingThread.php
+++ b/app/Models/JobHuntingThread.php
@@ -78,4 +78,12 @@ class JobHuntingThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the job hunting thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/LectureThread.php
+++ b/app/Models/LectureThread.php
@@ -78,4 +78,12 @@ class LectureThread extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    /**
+     * Get the thread image path associated with the lecture thread.
+     */
+    public function thread_image_path()
+    {
+        return $this->hasOne(ThreadImagePath::class);
+    }
 }

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -22,14 +22,4 @@ class Session extends Model
      * @var string
      */
     protected $table = 'sessions';
-
-    /**
-     * The attributes that should be cast.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'created_at' => 'datetime:Y-m-d H:i:s',
-        'update_at' => 'datetime:Y-m-d H:i:s',
-    ];
 }

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -22,4 +22,14 @@ class Session extends Model
      * @var string
      */
     protected $table = 'sessions';
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
+    ];
 }

--- a/app/Models/ThreadImagePath.php
+++ b/app/Models/ThreadImagePath.php
@@ -40,16 +40,6 @@ class ThreadImagePath extends Model
     ];
 
     /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array
-     */
-    protected $hidden = [
-        'img_path',
-        'img_size'
-    ];
-
-    /**
      * The attributes that should be cast.
      *
      * @var array

--- a/app/Models/ThreadImagePath.php
+++ b/app/Models/ThreadImagePath.php
@@ -29,9 +29,12 @@ class ThreadImagePath extends Model
      * @var string[]
      */
     protected $fillable = [
-        'thread_id',
-        'message_id',
-        'user_email',
+        'club_thread_id',
+        'college_year_thread_id',
+        'department_thread_id',
+        'job_hunting_thread_id',
+        'lecture_thread_id',
+        'user_id',
         'img_path',
         'img_size',
     ];
@@ -42,7 +45,6 @@ class ThreadImagePath extends Model
      * @var array
      */
     protected $hidden = [
-        'thread_id',
         'img_path',
         'img_size'
     ];
@@ -53,7 +55,47 @@ class ThreadImagePath extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
+
+    /**
+     * Get the club thread that owns the thread image path.
+     */
+    public function club_thread()
+    {
+        return $this->belongsTo(ClubThread::class);
+    }
+
+    /**
+     * Get the college year thread that owns the thread image path.
+     */
+    public function college_year_thread()
+    {
+        return $this->belongsTo(CollegeYearThread::class);
+    }
+
+    /**
+     * Get the department thread that owns the thread image path.
+     */
+    public function department_thread()
+    {
+        return $this->belongsTo(DepartmentThread::class);
+    }
+
+    /**
+     * Get the job hunting thread that owns the thread image path.
+     */
+    public function job_hunting_thread()
+    {
+        return $this->belongsTo(JobHuntingThread::class);
+    }
+
+    /**
+     * Get the lecture thread that owns the thread image path.
+     */
+    public function lecture_thread()
+    {
+        return $this->belongsTo(LectureThread::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -71,7 +71,9 @@ class User extends Authenticatable implements MustVerifyEmail
      * @var array
      */
     protected $casts = [
-        'email_verified_at' => 'datetime',
+        'email_verified_at' => 'datetime:Y-m-d H:i:s',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 
     /**

--- a/database/migrations/2022_10_15_151605_add_column_club_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151605_add_column_club_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('club_thread_id')->nullable(true)->after('id')->constrained('club_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['club_thread_id']);
+            $table->dropColumn('club_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151621_add_column_college_year_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151621_add_column_college_year_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('college_year_thread_id')->nullable(true)->after('club_thread_id')->constrained('college_year_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['college_year_thread_id']);
+            $table->dropColumn('college_year_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151640_add_column_department_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151640_add_column_department_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('department_thread_id')->nullable(true)->after('college_year_thread_id')->constrained('department_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['department_thread_id']);
+            $table->dropColumn('department_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151714_add_column_job_hunting_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151714_add_column_job_hunting_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('job_hunting_thread_id')->nullable(true)->after('department_thread_id')->constrained('job_hunting_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['job_hunting_thread_id']);
+            $table->dropColumn('job_hunting_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_151738_add_column_lecture_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_151738_add_column_lecture_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignId('lecture_thread_id')->nullable(true)->after('job_hunting_thread_id')->constrained('lecture_threads');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['lecture_thread_id']);
+            $table->dropColumn('lecture_thread_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_153505_add_column_user_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_153505_add_column_user_id_to_thread_image_paths_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->after('lecture_thread_id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_154007_drop_column_thread_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_154007_drop_column_thread_id_to_thread_image_paths_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->string('thread_id')->after('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_154030_drop_column_message_id_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_154030_drop_column_message_id_to_thread_image_paths_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropColumn('message_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->string('message_id')->after('user_id');
+        });
+    }
+};

--- a/database/migrations/2022_10_15_154055_drop_column_user_email_to_thread_image_paths_table.php
+++ b/database/migrations/2022_10_15_154055_drop_column_user_email_to_thread_image_paths_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropColumn('user_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->string('user_email')->after('user_id');
+        });
+    }
+};

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -83,8 +83,8 @@ function reload() {
       msg = data[item]['message'];
       show = "" + "<a " + "id='thread_message_id_" + data[item]['message_id'] + "' " + "href='#dashboard_send_comment_label' " + "type='button' " + "onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
-      if (data[item]['img_path'] != null) {
-        show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";
+      if (data[item]['thread_image_path'] !== null) {
+        show += "" + "<p>" + "<img src='" + url + data[item]['thread_image_path']['img_path'].replace('public', '/storage') + "'>" + "</p>";
       }
 
       show += "" + "<br>" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' ";

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -43,10 +43,10 @@ function reload() {
                 msg +
                 "</p>";
 
-            if (data[item]['img_path'] != null) {
+            if (data[item]['thread_image_path'] !== null) {
                 show += "" +
                     "<p>" +
-                    "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" +
+                    "<img src='" + url + data[item]['thread_image_path']['img_path'].replace('public', '/storage') + "'>" +
                     "</p>";
             }
 


### PR DESCRIPTION
## なぜこの変更をするのか

- `likes` テーブルのリレーション設定だけでは書き込まれた画像の取得が出来なかったため

## やったこと

- `thread_image_paths` テーブルに外部キー  `club_thread_id`, `college_year_thread_id`, `department_thread_id`, `job_hunting_thread_id`, `lecture_thread_id`, `user_id` を追加
- `thread_image_paths` テーブルの `thread_id`, `message_id`, `user_email` カラムを削除
- Eloquent: Relationships を利用・変更したカラムにデータを挿入，出来る様にモデルの変更
- スレッドの書き込み取得・書き込み・いいね機能が動作するように変更

## やらないこと

無し

## できるようになること（ユーザ目線）

- スレッドにアップロードされた画像の取得が出来る様になる

## できなくなること（ユーザ目線）

無し

## 動作確認

- 全ての大枠カテゴリでスレッド作成ができることを確認
- 全ての大枠カテゴリでスレッドの閲覧・書き込み・いいねができることを確認

## その他

リレーション未設定テーブル

- `thread_categorys`
- `users`
- `user_page_themas`